### PR TITLE
Convert attr names into kebab case format

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -1,9 +1,16 @@
 export const Prop = (): any => {
   return (target: any, propName: any) => {
+    const toKebabCase = str => {
+      return str
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .replace(/[\s_]+/g, '-')
+        .toLowerCase();
+    };
+    const attrName = toKebabCase(propName);
     function get() {
       const getAttribute = (propName) => {
         if(this.hasAttribute(propName)){
-          const attrValue = this.getAttribute(propName);
+          const attrValue = this.getAttribute(attrName);
           return attrValue == '' ? true : attrValue;
         }
         return false;
@@ -11,16 +18,16 @@ export const Prop = (): any => {
       if (!this.props) {
         this.props = {};
       }
-      return this.props[propName] || getAttribute(propName);
+      return this.props[propName] || getAttribute(attrName);
     }
     function set(value: any) {
       const oldValue = this[propName];
       this.props[propName] = value;
       if(this.__connected){
         if(typeof value != 'object'){
-          this.setAttribute(propName, value);
+          this.setAttribute(attrName, value);
         } else {
-          this.attributeChangedCallback(propName, oldValue, value);
+          this.attributeChangedCallback(attrName, oldValue, value);
         }
       }
     }

--- a/tests/decorators.spec.ts
+++ b/tests/decorators.spec.ts
@@ -2,17 +2,24 @@ import { CustomElement, Watch, Prop, Dispatch, DispatchEmitter, Listen } from 'c
 
 @CustomElement({
   tag: 'my-element',
-  template: '<span>my element</span>',
+  template: '<h1>page title</h1><span>my element</span>',
   style: ':host{border:0}'
 })
 export class MyElement extends HTMLElement {
 
   @Prop() name = 'my element';
+  @Prop() pageTitle = 'page title';
 
   @Watch('name')
   setSpan(value){
     const span = this.shadowRoot.querySelector('span');
     span.innerHTML = value.new;
+  }
+
+  @Watch('page-title')
+  setPageTitle(value){
+    const h1 = this.shadowRoot.querySelector('h1');
+    h1.innerHTML = value.new;
   }
 }
 
@@ -25,7 +32,7 @@ describe('decorators', () => {
   });
 
   it('should load html template', () => {
-      expect(myElementInstance.shadowRoot.innerHTML).toContain('<span>my element</span>');
+    expect(myElementInstance.shadowRoot.innerHTML).toContain('<span>my element</span>');
   });
 
   it('should load css', () => {
@@ -34,13 +41,19 @@ describe('decorators', () => {
 
   it('should re-render setting property', () => {
     myElementInstance.name = 'Aivan';
+    myElementInstance.pageTitle = 'Custom Element Rocks';
     expect(myElementInstance.shadowRoot.querySelector('span').innerHTML).toEqual('Aivan');
+    expect(myElementInstance.shadowRoot.querySelector('h1').innerHTML).toEqual('Custom Element Rocks');
   });
 
   it('should call method decorated with @Watch on prop change', () => {
     const watchSpy = spyOn(myElementInstance,'setSpan');
     myElementInstance.name = 'Aivan';
     expect(watchSpy).toHaveBeenCalled();
+
+    const pageTitleSpy = spyOn(myElementInstance,'setPageTitle');
+    myElementInstance.pageTitle = 'Custom Element Rocks';
+    expect(pageTitleSpy).toHaveBeenCalled();
   });
 
   it('should call method decorated with @Watch on prop change', () => {
@@ -53,11 +66,17 @@ describe('decorators', () => {
   it('should reflect as property', () => {
     myElementInstance.setAttribute('name', 'Mario');
     expect(myElementInstance.name).toEqual('Mario');
+
+    myElementInstance.setAttribute('page-title', 'Web Components');
+    expect(myElementInstance.pageTitle).toEqual('Web Components');
   });
 
   it('should reflect as dom attribute', () => {
     myElementInstance.name = 'Aivan';
     expect(myElementInstance.getAttribute('name')).toEqual('Aivan');
+
+    myElementInstance.pageTitle = 'Custom Element';
+    expect(myElementInstance.getAttribute('page-title')).toEqual('Custom Element');
   });
 
   it('should not reflect as dom attribute', () => {


### PR DESCRIPTION
Make used of kebab case format for attribute names with multiple words.

e.g
@Prop() pageTitle; // will have page-title attribute <my-element page-title="Page Title"></my-element>

@Watch('page-title')
setPageTitle() { ... }